### PR TITLE
Handle compiler errors in test output

### DIFF
--- a/gotest-ui.el
+++ b/gotest-ui.el
@@ -308,9 +308,11 @@ Whenever a test enters this state, it is automatically expanded."
       (with-current-buffer gotest-ui--process-buffer
         (setq gotest-ui--ui-buffer buffer))
       (setq gotest-ui--process
-            (apply 'start-process name gotest-ui--process-buffer cmdline))
-      (set-process-filter gotest-ui--process #'gotest-ui-read-json)
-      (set-process-sentinel gotest-ui--process #'gotest-ui--process-sentinel))))
+            (make-process :name name
+                          :buffer gotest-ui--process-buffer
+                          :sentinel #'gotest-ui--process-sentinel
+                          :filter #'gotest-ui-read-json
+                          :command cmdline)))))
 
 (defun gotest-ui-pp-status (status)
   (propertize (format "%s" status)

--- a/gotest-ui.el
+++ b/gotest-ui.el
@@ -177,7 +177,8 @@ Whenever a test enters this state, it is automatically expanded."
   (string-to-number (get-text-property (point) 'gotest-ui-line)))
 
 (defun gotest-ui-file-from-gopath (package file-basename)
-  (if (file-name-absolute-p file-basename)
+  (if (or (file-name-absolute-p file-basename)
+          (string-match-p "/" file-basename))
       file-basename
     (let ((gopath (or (getenv "GOPATH")
                       (expand-file-name "~/go"))))

--- a/gotest-ui.el
+++ b/gotest-ui.el
@@ -465,12 +465,13 @@ Whenever a test enters this state, it is automatically expanded."
 
 (defun gotest-ui-read-test-event (proc ui-buffer)
   (goto-char (process-mark proc))
+  (when (= (point) (line-end-position))
+    (forward-line 1))
   (case (char-after (point))
     (?\{
      ;; It's JSON:
      (condition-case err
          (let ((obj (json-read)))
-           (forward-line 1)
            (set-marker (process-mark proc) (point))
            (with-current-buffer ui-buffer
              (cons (gotest-ui-update-test-status obj) t)))

--- a/gotest-ui.el
+++ b/gotest-ui.el
@@ -554,14 +554,14 @@ Whenever a test enters this state, it is automatically expanded."
   (cl-destructuring-bind (test-suite test-name) (go-test--get-current-test-info)
     (let ((test-flag (if (> (length test-suite) 0) "-m" "-run")))
       (when test-name
-        (gotest-ui (gotest-ui--command-line test-flag (s-concat test-name "\\$") "."))))))
+        (gotest-ui (gotest-ui--command-line test-flag (s-concat test-name "$") "."))))))
 
 ;;;###autoload
 (defun gotest-ui-current-file ()
   "Launch go test on the current buffer file."
   (interactive)
   (let* ((data (go-test--get-current-file-testing-data))
-         (run-flag (s-concat "-run=" data "\\$")))
+         (run-flag (s-concat "-run=" data "$")))
     (gotest-ui (gotest-ui--command-line run-flag "."))))
 
 ;;;###autoload

--- a/gotest-ui.el
+++ b/gotest-ui.el
@@ -121,8 +121,7 @@ Whenever a test enters this state, it is automatically expanded."
 (cl-defun gotest-ui--make-test (ewoc &rest args &key status package name &allow-other-keys)
   (let ((test (apply #'gotest-ui--make-test-1 :status (or status "run") args)))
     (let ((node (ewoc-enter-last ewoc test)))
-      (setf (gethash test gotest-ui--nodes) node
-            (gotest-ui-thing-node test) node))
+      (setf (gotest-ui-thing-node test) node))
     test))
 
 ;;; Data manipulation routines:
@@ -256,11 +255,9 @@ Whenever a test enters this state, it is automatically expanded."
   (setq gotest-ui--cmdline cmdline
         gotest-ui--dir dir)
   (let ((ewoc (ewoc-create 'gotest-ui--pp-test nil nil t))
-        (tests (make-hash-table :test #'equal))
-        (nodes (make-hash-table :test #'eql)))
+        (tests (make-hash-table :test #'equal)))
     (setq gotest-ui--tests tests)
     (setq gotest-ui--ewoc ewoc)
-    (setq gotest-ui--nodes nodes)
     ;; Drop in the first few ewoc nodes:
     (setq gotest-ui--status (gotest-ui--make-status ewoc cmdline dir))
     ))
@@ -287,7 +284,6 @@ Whenever a test enters this state, it is automatically expanded."
 
 (defvar-local gotest-ui--tests nil)
 (defvar-local gotest-ui--ewoc nil)
-(defvar-local gotest-ui--nodes nil)
 (defvar-local gotest-ui--status nil)
 (defvar-local gotest-ui--process-buffer nil)
 (defvar-local gotest-ui--stderr-process-buffer nil)
@@ -492,7 +488,7 @@ Whenever a test enters this state, it is automatically expanded."
               test node)
          (with-current-buffer ui-buffer
            (setq test (gotest-ui-ensure-test gotest-ui--ewoc package-name nil :status 'fail)
-                 node (gethash test gotest-ui--nodes))
+                 node (gotest-ui-thing-node test))
            (setf (gotest-ui-test-reason test) reason)
            (gotest-ui-maybe-expand test))
          (forward-line 1)
@@ -543,7 +539,7 @@ Whenever a test enters this state, it is automatically expanded."
          (gotest-ui-maybe-expand test))
         (otherwise
          (setq test nil)))
-      (when test (gethash test gotest-ui--nodes)))))
+      (when test (gotest-ui-thing-node test)))))
 
 ;;;; Commands for go-mode:
 

--- a/gotest-ui.el
+++ b/gotest-ui.el
@@ -112,7 +112,7 @@ Whenever a test enters this state, it is automatically expanded."
   (node))
 
 (cl-defun gotest-ui--make-status (ewoc cmdline dir)
-  (let ((status (gotest-ui--make-status-1 :state "run" :cmdline cmdline :dir dir)))
+  (let ((status (gotest-ui--make-status-1 :state "run" :cmdline (s-join " " cmdline) :dir dir)))
     (let ((node (ewoc-enter-first ewoc status)))
       (setf (gotest-ui-status-node status) node))
     status))
@@ -295,7 +295,7 @@ Whenever a test enters this state, it is automatically expanded."
 
 (cl-defun gotest-ui (cmdline &key dir)
   (let* ((dir (or dir default-directory))
-         (name (format "*go test: %s in %s" cmdline dir))
+         (name (format "*go test: %s in %s" (s-join " " cmdline) dir))
          (buffer (get-buffer-create name)))
     (unless (eql buffer (current-buffer))
       (switch-to-buffer-other-window buffer))


### PR DESCRIPTION
# What

This PR updates the process output handling to read from stdout and stderr separately, updates the commandline handling and thing->node mapping.

# Why
It turns out `go test` spews compiler errors to stderr, and I'd like to see those (with clickable links) in regular test case output.