### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/gotest-ui.el
+++ b/gotest-ui.el
@@ -87,6 +87,20 @@ Whenever a test enters this state, it is automatically expanded."
   :group 'gotest-ui
   :type '(repeat string))
 
+(defvar-local gotest-ui--tests nil)
+(defvar-local gotest-ui--section-alist nil)
+(defvar-local gotest-ui--ewoc nil)
+(defvar-local gotest-ui--status nil)
+(defvar-local gotest-ui--process-buffer nil)
+(defvar-local gotest-ui--stderr-process-buffer nil)
+(defvar-local gotest-ui--ui-buffer nil)
+(defvar-local gotest-ui--process nil)
+(defvar-local gotest-ui--stderr-process nil)
+(defvar-local gotest-ui--cmdline nil)
+(defvar-local gotest-ui--dir nil)
+(defvar gotest-ui-parse-marker)
+(defvar gotest-ui-insertion-marker)
+
 ;;;; Data model:
 
 (cl-defstruct (gotest-ui-section :named
@@ -379,18 +393,6 @@ that it indicates."
   (gotest-ui gotest-ui--cmdline :dir gotest-ui--dir))
 
 ;;;; Displaying the data:
-
-(defvar-local gotest-ui--tests nil)
-(defvar-local gotest-ui--section-alist nil)
-(defvar-local gotest-ui--ewoc nil)
-(defvar-local gotest-ui--status nil)
-(defvar-local gotest-ui--process-buffer nil)
-(defvar-local gotest-ui--stderr-process-buffer nil)
-(defvar-local gotest-ui--ui-buffer nil)
-(defvar-local gotest-ui--process nil)
-(defvar-local gotest-ui--stderr-process nil)
-(defvar-local gotest-ui--cmdline nil)
-(defvar-local gotest-ui--dir nil)
 
 (cl-defun gotest-ui (cmdline &key dir)
   "Invoke `go test` with CMDLINE in DIR.


### PR DESCRIPTION
declare global variables and declare them before them used

```
In gotest-ui-ensure-test:
gotest-ui.el:160:32:Warning: reference to free variable ‘gotest-ui--tests’

In gotest-ui-update-status:
gotest-ui.el:165:33:Warning: reference to free variable ‘gotest-ui--status’
gotest-ui.el:166:20:Warning: reference to free variable ‘gotest-ui--ewoc’

In gotest-ui-ensure-output-buffer:
gotest-ui.el:175:47:Warning: assignment to free variable
    ‘gotest-ui-parse-marker’
gotest-ui.el:176:34:Warning: assignment to free variable
    ‘gotest-ui-insertion-marker’
gotest-ui.el:176:8:Warning: reference to free variable
    ‘gotest-ui-insertion-marker’

In gotest-ui-ensure-parsed:
gotest-ui.el:228:16:Warning: reference to free variable
    ‘gotest-ui-parse-marker’
gotest-ui.el:229:65:Warning: reference to free variable
    ‘gotest-ui-insertion-marker’

In gotest-ui-update-thing-output:
gotest-ui.el:244:16:Warning: reference to free variable
    ‘gotest-ui-insertion-marker’

In gotest-ui--clear-buffer:
gotest-ui.el:283:28:Warning: reference to free variable
    ‘gotest-ui--process-buffer’

In gotest-ui--setup-buffer:
gotest-ui.el:298:9:Warning: assignment to free variable ‘gotest-ui--cmdline’
gotest-ui.el:299:9:Warning: assignment to free variable ‘gotest-ui--dir’
gotest-ui.el:302:11:Warning: assignment to free variable ‘gotest-ui--tests’
gotest-ui.el:306:28:Warning: assignment to free variable ‘gotest-ui--ewoc’
gotest-ui.el:305:11:Warning: assignment to free variable ‘gotest-ui--status’
gotest-ui.el:307:28:Warning: reference to free variable ‘gotest-ui--ewoc’
gotest-ui.el:312:24:Warning: assignment to free variable
    ‘gotest-ui--stderr-process-buffer’
gotest-ui.el:312:24:Warning: reference to free variable
    ‘gotest-ui--stderr-process-buffer’
gotest-ui.el:316:11:Warning: assignment to free variable
    ‘gotest-ui--ui-buffer’
gotest-ui.el:315:24:Warning: assignment to free variable
    ‘gotest-ui--process-buffer’
gotest-ui.el:315:24:Warning: reference to free variable
    ‘gotest-ui--process-buffer’

In gotest-ui-add-section:
gotest-ui.el:323:32:Warning: reference to free variable
    ‘gotest-ui--section-alist’
gotest-ui.el:323:32:Warning: assignment to free variable
    ‘gotest-ui--section-alist’

In gotest-ui-sort-test-into-section:
gotest-ui.el:346:33:Warning: reference to free variable
    ‘gotest-ui--section-alist’
gotest-ui.el:341:22:Warning: reference to free variable ‘gotest-ui--ewoc’

In gotest-ui-toggle-expanded:
gotest-ui.el:369:29:Warning: reference to free variable ‘gotest-ui--ewoc’

In gotest-ui-rerun:
gotest-ui.el:379:14:Warning: reference to free variable ‘gotest-ui--cmdline’
gotest-ui.el:379:38:Warning: reference to free variable ‘gotest-ui--dir’
```